### PR TITLE
Propose new recommended community policy R7

### DIFF
--- a/package_policies/R7.md
+++ b/package_policies/R7.md
@@ -1,12 +1,16 @@
-**R7.** It is recommended that each package should have a README and a LICENSE file in its top directory.
-The README file should contain the following information:
-
-- a link to the package webpage
-
-- contact information, i.e. how to get help (**M5**)
+**R7.** It is recommended that each package should have a README or README.md, a SUPPORT or SUPPORT.md, a LICENSE or LICENSE.md, and a CHANGELOG or CHANGLOG.md file in its top directory.
+The README file should contain at least the following information:
 
 - a **brief** description of the package
 
-- license information.
+- information on how to install the package
 
-The LICENSE file should contain the full text of the license. If the full text can be found via a link to a website it is sufficient to provide this link in the README file.
+- a link to the package webpage (if there is one)
+
+The LICENSE file should contain the full text of the license. If the full text can be found in a different directory or via a link to a website it is sufficient to provide a link to the full text in the file.
+
+The SUPPORT file should contain the contact information that is required by community policy **M5** to be able to get help.
+
+The CHANGELOG file should contain important changes or a link to a file or webpage with this information, but not each individual commit.
+
+If providing additional information, e.g. on how to contribute, authorship, code of conduct, etc, it is recommended to consider suggestions in https://github.com/kmindi/special-files-in-repository-root/blob/master/README.md 

--- a/package_policies/R7.md
+++ b/package_policies/R7.md
@@ -1,4 +1,4 @@
-**R7.** It is recommended that each package should have a README or README.md, a SUPPORT or SUPPORT.md, a LICENSE or LICENSE.md, and a CHANGELOG or CHANGLOG.md file in its top directory.
+**R7.** It is recommended that each package should have a README or README.md, a SUPPORT or SUPPORT.md, a LICENSE or LICENSE.md, and a CHANGELOG or CHANGELOG.md file in its top directory.
 The README file should contain at least the following information:
 
 - a **brief** description of the package

--- a/package_policies/R7.md
+++ b/package_policies/R7.md
@@ -3,7 +3,7 @@ The README file should contain at least the following information:
 
 - a **brief** description of the package
 
-- information on how to install the package
+- information on how to install the package or a link to a file (e.g. INSTALL, INSTALL.md or similar) or a website with the installation information
 
 - a link to the package webpage (if there is one)
 

--- a/package_policies/R7.md
+++ b/package_policies/R7.md
@@ -1,0 +1,12 @@
+**R7.** It is recommended that each package should have a README and a LICENSE file in its top directory.
+The README file should contain the following information:
+
+- a link to the package webpage
+
+- contact information, i.e. how to get help (**M5**)
+
+- a **brief** description of the package
+
+- license information.
+
+The LICENSE file should contain the full text of the license. If the full text can be found via a link to a website it is sufficient to provide this link in the README file.

--- a/package_policies/R7.md
+++ b/package_policies/R7.md
@@ -11,6 +11,6 @@ The LICENSE file should contain the full text of the license. If the full text c
 
 The SUPPORT file should contain the contact information that is required by community policy **M5** to be able to get help.
 
-The CHANGELOG file should contain important changes or a link to a file or webpage with this information, but not each individual commit.
+The CHANGELOG file should contain important changes or a link to a file or webpage with this information, but not each individual commit message.
 
 If providing additional information, e.g. on how to contribute, authorship, code of conduct, etc, it is recommended to consider suggestions in https://github.com/kmindi/special-files-in-repository-root/blob/master/README.md 

--- a/package_policies/README.md
+++ b/package_policies/README.md
@@ -102,6 +102,7 @@ In addition to the required xSDK policies listed above, the following capabiliti
 
 **R6.** [Document versions of packages that it works with or depends upon, preferably in machine-readable form.](/package_policies/R6.md)
 
+**R7.** [Have README, SUPPORT, LICENSE, and CHANGELOG files in top directory.](/package_policies/R7.md)
 ## History of the xSDK Community Policies
 
 The original version of this document was prepared in 2015 by Barry Smith with key input from Roscoe Bartlett


### PR DESCRIPTION
Due to a request by the facilities for a well defined space on package information, we are in the process of formulating a new recommended community policy. This is a first preliminary draft to get the process started.