### PR TITLE
Update M3.md

### DIFF
--- a/package_policies/M3.md
+++ b/package_policies/M3.md
@@ -1,7 +1,7 @@
 **M3.** Each xSDK-compatible package that utilizes MPI must restrict its MPI operations to MPI
 communicators that are provided to it and not use directly MPI_COMM_WORLD. The package should
-use configure tests or version tests to detect MPI 2 or MPI 3 features that may not be available; it
-should not be assumed that a full MPI 2 or MPI 3 implementation is available. The package can
+use configure tests or version tests to detect MPI 3 features that may not be available; it
+should not be assumed that a full MPI 3 implementation is available. The package can
 change the MPI error-handling mode by default but should have an option to prevent it from changing
 the MPI error handling (which may have been set by another package or the application). The
 package should also behave appropriately regardless of the MPI error handling being used. There is


### PR DESCRIPTION
Removed requirement to detect MPI 2 features, since they appear to be generally available at this time.