### PR TITLE
Update 13.md

### DIFF
--- a/installation_policies/13.md
+++ b/installation_policies/13.md
@@ -1,3 +1,2 @@
 13. After an install the package should provide a machine-readable output to show provenance, that is, what compilers were 
-used and what libraries were linked with, as well as other build configuration information if this information was also 
-stored in the install directory somewhere, so that users with problems can send the information directly to developers.
+used and what libraries were linked with, as well as other build configuration information, so that users with problems can send the information directly to developers.


### PR DESCRIPTION
removed subclause following Barry's suggestion:
"Suggest dropping "if this information was also stored in the install directory somewhere," The information should be provided in the install directory so there should be no question of "if this information was also stored""