### PR TITLE
M12: replace unclear "against" with "to"; fix Suitesparse typo

### DIFF
--- a/package_policies/M12.md
+++ b/package_policies/M12.md
@@ -1,5 +1,5 @@
 **M12.** If a package imports software that is externally developed and maintained,<sup>8</sup> then it must allow
-installing, building, and linking against an outside copy of that software. Acceptable ways to
+installing, building, and linking to an outside copy of that software. Acceptable ways to
 accomplish this include (1) forsaking the internal copied version and using an externally provided
 implementation or (2) changing the file names and namespaces of all global symbols to allow the
 internal copy and the external copy to coexist in the same downstream libraries and programs.
@@ -8,5 +8,5 @@ internal copy and the external copy to coexist in the same downstream libraries 
 
 <sup>8</sup> For example, some projects import source for some routines from BLAS and LAPACK. The Trilinos Teuchos
 package imported an early version of the boost::any class. Also, Trilinos has its own copy of an older version of
-SparseSuite. In the latter two cases, new file names and namespaces were created for the imported software to
+SuiteSparse. In the latter two cases, new file names and namespaces were created for the imported software to
 allow coexistence with the (updated) external versions.

--- a/package_policies/M12.md
+++ b/package_policies/M12.md
@@ -1,5 +1,5 @@
 **M12.** If a package imports software that is externally developed and maintained,<sup>8</sup> then it must allow
-installing, building, and linking to an outside copy of that software. Acceptable ways to
+installing, building, and linking with an outside copy of that software. Acceptable ways to
 accomplish this include (1) forsaking the internal copied version and using an externally provided
 implementation or (2) changing the file names and namespaces of all global symbols to allow the
 internal copy and the external copy to coexist in the same downstream libraries and programs.


### PR DESCRIPTION
Reported-by: Stefan Wild <wild@anl.gov>